### PR TITLE
Initial Flask server app

### DIFF
--- a/enamel/main.py
+++ b/enamel/main.py
@@ -1,0 +1,74 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+import sys
+
+import flask
+from oslo_config import cfg
+
+from enamel import opts
+
+
+app = flask.Flask(__name__)
+
+
+def create_link_object(urls):
+    links = []
+    for url in urls:
+        links.append({"rel": "self",
+                      "href": os.path.join(flask.request.url_root, url)})
+    return links
+
+
+def generate_resource_data(resources):
+    data = []
+    for resource in resources:
+        item = {}
+        item['name'] = str(resource).split('/')[-1]
+        item['links'] = create_link_object([str(resource)[1:]])
+        data.append(item)
+    return data
+
+
+@app.route('/', methods=['GET'])
+def api_root():
+    pat = re.compile("^\/[^\/]*?$")
+
+    resources = []
+    for url in app.url_map.iter_rules():
+        if pat.match(str(url)):
+            resources.append(url)
+
+    return flask.jsonify(resources=generate_resource_data(resources))
+
+
+@app.route('/servers', methods=['POST'])
+def server_boot():
+    data = flask.request.get_json()
+    # TODO: Call the task workflow here and return a link to the task
+    task_return = data
+    return flask.jsonify(task_return)
+
+
+def main(args=sys.argv[1:]):
+    conf = cfg.ConfigOpts()
+    conf(args, project='enamel')
+    for group, options in opts.list_opts():
+        conf.register_opts(list(options),
+                group=None if group == "DEFAULT" else group)
+    app_kwargs = {'host': conf.api.bind_address,
+                  'port': conf.api.bind_port}
+
+    app.run(**app_kwargs)

--- a/enamel/opts.py
+++ b/enamel/opts.py
@@ -1,0 +1,25 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from oslo_config import cfg
+
+
+def list_opts():
+    return [
+        ("api", (
+            cfg.PortOpt('bind_port',
+                        default=5050,
+                        help='The port for the Enamel API server.'),
+            cfg.StrOpt('bind_address',
+                       default='0.0.0.0',
+                       help='The listen IP for the Enamel API server.'),
+        ))]

--- a/example.conf
+++ b/example.conf
@@ -1,0 +1,7 @@
+[api]
+
+# IP to listen on. (string value)
+bind_address = 0.0.0.0
+
+# Port to listen on. (integer value)
+bind_port = 5050

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,12 @@ classifier =
 packages =
     enamel
 
+[entry_points]
+console_scripts =
+    enamel = enamel.main:main
+oslo.config.opts =
+    enamel = enamel.opts:list_opts
+
 [build_sphinx]
 all_files = 1
 build-dir = docs/build


### PR DESCRIPTION
This adds enough of a skeleton to have a Flask app running and listing
available resources for GET /.  It also adds an example config file to
use with the server.  For now it can be run as 'enamel --config-file
example.conf'.  The servers resource is not fully implemented but is in
place to show that GET / works.