### PR TITLE
Integrate gabbi tests by de-globalizing the flask app

### DIFF
--- a/enamel/tests/functional/gabbi/gabbits/basic.yaml
+++ b/enamel/tests/functional/gabbi/gabbits/basic.yaml
@@ -9,8 +9,8 @@ fixtures:
 tests:
 
     - name: get json home
-      xfail: nope not gonna do it
       GET: /
+      xfail: this will get the wrong content type and content
       status: 200
       response_headers:
           # NOTE(cdent): There's noise on the interwebs that this

--- a/enamel/tests/functional/gabbi/test_gabbi.py
+++ b/enamel/tests/functional/gabbi/test_gabbi.py
@@ -20,24 +20,15 @@ import os
 
 from gabbi import driver
 
+from enamel import main
 from enamel.tests.functional.gabbi import fixtures as fixture_module
 
 TESTS_DIR = 'gabbits'
-
-
-# NOTE(cdent): Replace with real wsgi app factory.
-def load_app():
-
-    def stub(environ, start_response):
-        start_response('200 OK', [])
-        return ['']
-
-    return stub
 
 
 def load_tests(loader, tests, pattern):
     """Provide a TestSuite to the discovery process."""
     test_dir = os.path.join(os.path.dirname(__file__), TESTS_DIR)
     return driver.build_tests(test_dir, loader, host=None,
-                              intercept=load_app,
+                              intercept=main.create_app,
                               fixture_module=fixture_module)


### PR DESCRIPTION
Gabbi prefers an app factory to use to get the WSGI app that it
will intercept for testing. Once we have this factory it then makes
sense to not make 'app' a module level variable and instead pass it
around to configuration functions.

The upshot of this is that we now have a single function which adds
route-function pairs and where we do need to get 'app' we can request
it from the flask module property 'current_app'. If you are of a mind
that global stuff is bad and that centralized routing is good, this
is all a win.

The gabbi test in basic.yaml is expecting a response formatted as JSON
Home. Since it is not currently getting that it is marked to xfail.