### PR TITLE
Adjust service startup to allow keystonemiddleware

### DIFF
--- a/enamel/opts.py
+++ b/enamel/opts.py
@@ -22,4 +22,8 @@ def list_opts():
             cfg.StrOpt('bind_address',
                        default='0.0.0.0',
                        help='The listen IP for the Enamel API server.'),
+            cfg.StrOpt('auth_strategy',
+                       default='keystone',
+                       help='The authentication strategy. '
+                            'Set to None to disable auth.'),
         ))]

--- a/enamel/tests/functional/gabbi/gabbits/keystone.yaml
+++ b/enamel/tests/functional/gabbi/gabbits/keystone.yaml
@@ -1,0 +1,15 @@
+#
+# Provide that keystone is intercepting requests.
+#
+
+fixtures:
+- AuthedConfigFixture
+
+tests:
+
+    - name: 401 happens
+      GET: /
+      status: 401
+      response_headers:
+          www-authenticate: Keystone uri='https://127.0.0.1:35357'
+

--- a/enamel/tests/functional/gabbi/test_gabbi.py
+++ b/enamel/tests/functional/gabbi/test_gabbi.py
@@ -20,8 +20,7 @@ import os
 
 from gabbi import driver
 
-from enamel import main
-from enamel.tests.functional.gabbi import fixtures as fixture_module
+from enamel.tests.functional.gabbi import fixtures
 
 TESTS_DIR = 'gabbits'
 
@@ -30,5 +29,5 @@ def load_tests(loader, tests, pattern):
     """Provide a TestSuite to the discovery process."""
     test_dir = os.path.join(os.path.dirname(__file__), TESTS_DIR)
     return driver.build_tests(test_dir, loader, host=None,
-                              intercept=main.create_app,
-                              fixture_module=fixture_module)
+                              intercept=fixtures.setup_app,
+                              fixture_module=fixtures)

--- a/example.conf
+++ b/example.conf
@@ -5,3 +5,11 @@ bind_address = 0.0.0.0
 
 # Port to listen on. (integer value)
 bind_port = 5050
+
+# Whether to use keystone
+auth_strategy = keystone
+
+# NOTE(cdent): Fake in bare minimum for now
+[keystone_authtoken]
+auth_plugin = password
+auth_url = http://127.0.0.1:35357


### PR DESCRIPTION
Some minor hoop jumping is required to use keystonemiddleware.auth_token
without paste: It's necessary to pass it a pointer to the oslo-config-
using project (in this case enamel) so it can find its own config.

At the same time it is useful to be able to turn off keystone for
functional tests or maybe some other auth strategy is desired. To
that end an 'auth_strategy' config option has been added. The gabbi
config fixtures have been extended to allow setting this to none.

Some potential issues with this setup:

* As is, all routes require auth. With things like / (which will return
  the json-home info) or /schemas it might be nice to be open.
* Currently the loading and applying of middleware is a crufty
  process in create_app rather than something declarative (like what
  paste would provide). It is not clear this is a problem. Very
  little middleware will be desired and pretty much all of it will
  be required and that's the way we want it to remain.