### PR TITLE
Move route handlers into enamel.api package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 .tox
 .testrepository
 enamel.egg-info
+cover
+.coverage

--- a/enamel/api/handlers.py
+++ b/enamel/api/handlers.py
@@ -1,0 +1,53 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+
+import flask
+
+
+def create_link_object(urls):
+    links = []
+    for url in urls:
+        links.append({"rel": "self",
+                      "href": os.path.join(flask.request.url_root, url)})
+    return links
+
+
+def generate_resource_data(resources):
+    data = []
+    for resource in resources:
+        item = {}
+        item['name'] = str(resource).split('/')[-1]
+        item['links'] = create_link_object([str(resource)[1:]])
+        data.append(item)
+    return data
+
+
+def home():
+    pat = re.compile("^\/[^\/]*?$")
+
+    resources = []
+    for url in flask.current_app.url_map.iter_rules():
+        if pat.match(str(url)):
+            resources.append(url)
+
+    return flask.jsonify(resources=generate_resource_data(resources))
+
+
+def server_boot():
+    data = flask.request.get_json()
+    # TODO(cdent): Call the task workflow here and return a link to the task
+    task_return = data
+    return flask.jsonify(task_return)

--- a/enamel/tests/functional/gabbi/gabbits/basic.yaml
+++ b/enamel/tests/functional/gabbi/gabbits/basic.yaml
@@ -21,6 +21,3 @@ tests:
           # this is made up and not expected to be correct
           $.resources['http://docs.openstack.org/api/openstack/1/rel/servers'].href: /servers
           $.resources['http://docs.openstack.org/api/openstack/1/rel/server'].href_template: /servers/{server_id}
-
-
-

--- a/enamel/tests/functional/gabbi/gabbits/servers.yaml
+++ b/enamel/tests/functional/gabbi/gabbits/servers.yaml
@@ -1,0 +1,22 @@
+#
+# Test the servers route.
+#
+
+fixtures:
+- ConfigFixture
+
+tests:
+
+    - name: check post
+      desc: this is a round tripper for dev purposes
+      POST: /servers
+      request_headers:
+          content-type: application/json
+      data:
+          type: the awesome kind
+          name: super cool
+      response_headers:
+          content-type: application/json
+      response_json_paths:
+          $.type: the awesome kind
+          $.name: super cool


### PR DESCRIPTION
This is a first step in having the api live in its own package.

To cover the /servers route across this change a servers.yaml
test file was added.