### PR TITLE
Strict content types in request/response

### DIFF
--- a/enamel/api/handlers.py
+++ b/enamel/api/handlers.py
@@ -47,7 +47,12 @@ def home():
 
 
 def server_boot():
+    # TODO(alaski): Rather than reimplenting this in every method it should be
+    # moved into a decorator or central location.
+    if flask.request.content_type != 'application/json':
+        flask.abort(415)
+    # This raises BadRequest if no data is provided with the POST.
     data = flask.request.get_json()
     # TODO(cdent): Call the task workflow here and return a link to the task
     task_return = data
-    return flask.jsonify(task_return)
+    return flask.make_response(flask.jsonify(task_return), 202)

--- a/enamel/tests/functional/gabbi/gabbits/basic.yaml
+++ b/enamel/tests/functional/gabbi/gabbits/basic.yaml
@@ -21,3 +21,31 @@ tests:
           # this is made up and not expected to be correct
           $.resources['http://docs.openstack.org/api/openstack/1/rel/servers'].href: /servers
           $.resources['http://docs.openstack.org/api/openstack/1/rel/server'].href_template: /servers/{server_id}
+
+    - name: server boot wrong content type
+      POST: /servers
+      data:
+          foo: bar
+      request_headers:
+          content-type: application/xml
+      status: 415
+      response_headers:
+          content-type: application/json
+
+    - name: server boot pass back data
+      POST: /servers
+      data:
+          foo: bar
+      request_headers:
+          content-type: application/json
+      status: 202
+      response_headers:
+          content-type: application/json
+
+    - name: server boot no post data
+      POST: /servers
+      request_headers:
+          content-type: application/json
+      status: 400
+      response_headers:
+          content-type: application/json

--- a/enamel/tests/functional/gabbi/gabbits/servers.yaml
+++ b/enamel/tests/functional/gabbi/gabbits/servers.yaml
@@ -15,6 +15,7 @@ tests:
       data:
           type: the awesome kind
           name: super cool
+      status: 202
       response_headers:
           content-type: application/json
       response_json_paths:


### PR DESCRIPTION
Strict validation is added to the server boot POST handler so that only
requests with content_type application/json are allowed.  Additionally
the error handlers are updated to return application/json responses
rather than the default of text/html.