### PR TITLE
Cleanup the test environment to be more useful

### DIFF
--- a/.testr.conf
+++ b/.testr.conf
@@ -1,5 +1,5 @@
 [DEFAULT]
-test_command=${PYTHON:-python} -m subunit.run discover enamel $LISTOPT $IDOPTION
+test_command=${PYTHON:-python} -m subunit.run discover -t . ${OS_TEST_PATH:-enamel} $LISTOPT $IDOPTION
 test_id_option=--load-list $IDFILE
 test_list_option=--list
 # NOTE(chdent): Only used/matches on gabbi-related tests.

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
       - TOXENV=py34
       - TOXENV=py35
       - TOXENV=pypy
-      - TOXENV=pypy3
       - TOXENV=pep8
       - TOXENV=functional
+      - TOXENV=py35-functional
+      - TOXENV=py34-functional

--- a/enamel/tests/functional/gabbi/gabbits/basic.yaml
+++ b/enamel/tests/functional/gabbi/gabbits/basic.yaml
@@ -14,7 +14,7 @@ tests:
       status: 200
       response_headers:
           # NOTE(cdent): There's noise on the interwebs that this
-          # should be application/home+json to follow others
+          # should be application/home+json to follow other
           # standards.
           content-type: application/json-home
       response_json_paths:

--- a/enamel/tests/unit/test_null.py
+++ b/enamel/tests/unit/test_null.py
@@ -1,0 +1,21 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import testtools
+
+
+class TestBase(testtools.TestCase):
+
+    def test_stub(self):
+        # to hold a place for confirming unit tests
+        self.assertTrue(True)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
 coverage
 gabbi
+os-testr
 testtools
-testrepository

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps = -r{toxinidir}/requirements.txt
 install_command = pip install -U {opts} {packages}
 setenv = OS_TEST_PATH=enamel/tests/unit/
 usedevelop = True
-commands = python setup.py testr --testr-args="{posargs}"
+commands = ostestr {posargs}
 
 [testenv:venv]
 deps = -r{toxinidir}/requirements.txt
@@ -20,6 +20,7 @@ commands = {posargs}
 
 [testenv:pep8]
 deps = hacking
+usedevelop = False
 commands =
     flake8
 
@@ -27,6 +28,12 @@ commands =
 commands = python setup.py testr --coverage --testr-args="{posargs}"
 
 [testenv:functional]
+setenv = OS_TEST_PATH=enamel/tests/functional/
+
+[testenv:py34-functional]
+setenv = OS_TEST_PATH=enamel/tests/functional/
+
+[testenv:py35-functional]
 setenv = OS_TEST_PATH=enamel/tests/functional/
 
 [testenv:docs]


### PR DESCRIPTION
* There is now a passing test in the unit test tree.
* .testr.conf correctly uses OS_TEST_PATH
* tests are run with ostestr instead of testr to get pretty_tox
  style output
* functional test targets (with corresponding travis entries) for
  py34 and py35