### PR TITLE
Make config more effective for auth_middleware

### DIFF
--- a/enamel/tests/functional/gabbi/gabbits/keystone.yaml
+++ b/enamel/tests/functional/gabbi/gabbits/keystone.yaml
@@ -8,8 +8,9 @@ fixtures:
 tests:
 
     - name: 401 happens
+      desc: by testing for http instead of https we confirm config override
       GET: /
       status: 401
       response_headers:
-          www-authenticate: Keystone uri='https://127.0.0.1:35357'
+          www-authenticate: Keystone uri='http://127.0.0.1:35357'
 

--- a/example.conf
+++ b/example.conf
@@ -12,4 +12,5 @@ auth_strategy = keystone
 # NOTE(cdent): Fake in bare minimum for now
 [keystone_authtoken]
 auth_plugin = password
-auth_url = http://127.0.0.1:35357
+auth_url = https://localhost:35357/
+auth_uri = https://localhost:35357/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Flask
 keystonemiddleware
 oslo.config
+oslo.log
 python-cinderclient
 python-glanceclient
 python-novaclient


### PR DESCRIPTION
This is not yet fully working because of bug #1540022 in
keystonemiddleware, however once fully working it will allow passing
the active and already loaded configuration into the middleware
in a straightforward fashion from both the test and non-test
environments and get rid of the call to the filter_factory (which
was redundant).

And the above bug is addressed the tests still pass and the server
still runs but it won't pay attention to the config values being set
in the example.conf file (when passed as a --config-file arg). For
the time being this isn't an issue as we aren't really doing anything
with auth. In live tests disable keystone setting auth_strategy to
something other than "keystone".

Additionally, logging is configured to ensure logging is visible
and logging and other configuration are centralized in a
prepare_service method so it can be reused by functional tests,
if necessary.