### PR TITLE
Set api.version.VERSIONS to real value

### DIFF
--- a/enamel/api/handlers.py
+++ b/enamel/api/handlers.py
@@ -32,12 +32,12 @@ def set_version():
 def send_version(response):
     """An after_request function to send microversion headers."""
     vary = response.headers.get('vary')
-    header = version.Version.header
+    header = version.Version.HEADER
     value = flask.g.request_version
     if vary:
-        response.headers['vary'] = '%s, %s' % (vary, version.Version.header)
+        response.headers['vary'] = '%s, %s' % (vary, header)
     else:
-        response.headers['vary'] = version.Version.header
+        response.headers['vary'] = header
     response.headers[header] = value
     return response
 

--- a/enamel/tests/functional/gabbi/test_gabbi.py
+++ b/enamel/tests/functional/gabbi/test_gabbi.py
@@ -20,7 +20,7 @@ import os
 
 from gabbi import driver
 
-from enamel.tests.functional.gabbi import fixtures
+from enamel.tests.functional.gabbi import helpers
 
 TESTS_DIR = 'gabbits'
 
@@ -29,5 +29,5 @@ def load_tests(loader, tests, pattern):
     """Provide a TestSuite to the discovery process."""
     test_dir = os.path.join(os.path.dirname(__file__), TESTS_DIR)
     return driver.build_tests(test_dir, loader, host=None,
-                              intercept=fixtures.setup_app,
-                              fixture_module=fixtures)
+                              intercept=helpers.setup_app,
+                              fixture_module=helpers)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
 coverage
 gabbi
+fixtures
 mock
 os-testr
 oslotest


### PR DESCRIPTION
The original value was for the sake of testing. Now testing is
handled by monkey patching VERSIONS from the tests. In the process
of doing this some issues with how the Version class was structured
were discovered.

Now the Version class is used to simply represent the version itself
and the constraints thereof. Code is extracted to module level
functions where it cannot be subclassed (we don't want it to be).
In the process cycles and dependencies in import handling are
avoided (making the monkey patching cleaner).