### PR TITLE
Update to require keystonemiddleware 4.3.0

### DIFF
--- a/enamel/main.py
+++ b/enamel/main.py
@@ -35,7 +35,6 @@ def create_app(conf):
     # a project with an oslo config.
     if conf.api.auth_strategy == 'keystone':
         auth_conf = {
-            'oslo_config_project': 'enamel',
             'log_name': __name__,
             'oslo_config_config': conf,
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask
 alembic
-keystonemiddleware
+keystonemiddleware>=4.3.0
 oslo.config
 oslo.db
 oslo.log


### PR DESCRIPTION
That version has my fix to allow oslo_config_config to work, which
means that we can read and manipulate a non-global config in code
and tests and then pass that config to the middleware for it to
use to configure itself.