### PR TITLE
Replace Version.in_window() with the more generic matches()

### DIFF
--- a/enamel/api/version.py
+++ b/enamel/api/version.py
@@ -79,8 +79,12 @@ class Version(collections.namedtuple('Version', 'major minor')):
             self.MIN_VERSION = parse_version_string(min_version_string())
         return self.MIN_VERSION
 
-    def in_window(self):
-        return self.min_version <= self <= self.max_version
+    def matches(self, min_version=None, max_version=None):
+        if min_version is None:
+            min_version = self.min_version
+        if max_version is None:
+            max_version = self.max_version
+        return min_version <= self <= max_version
 
 
 def extract_version(headers):
@@ -90,6 +94,6 @@ def extract_version(headers):
     # We need a version that is in VERSION and within MIX and MAX.
     # This gives us the option to administratively disable a
     # version if we really need to.
-    if (str(request_version) in VERSIONS and request_version.in_window()):
+    if (str(request_version) in VERSIONS and request_version.matches()):
         return request_version
     raise ValueError('Unacceptable version header: %s' % version_string)

--- a/enamel/tests/unit/api/test_version.py
+++ b/enamel/tests/unit/api/test_version.py
@@ -90,6 +90,39 @@ class TestVersion(MockVersionedTest):
         self.assertEqual('OpenStack-enamel-API-Version',
                          request_version.HEADER)
 
+    def test_matches_does_match(self):
+        request_version = version.parse_version_string('9.9')
+        # Version is a tuple under the hood
+        self.assertTrue(request_version.matches((1, 1), (10, 0)))
+
+    def test_matches_does_not_match(self):
+        request_version = version.parse_version_string('9.9')
+        self.assertFalse(request_version.matches((10, 1), (75, 0)))
+
+    def test_matches_does_not_match_weird(self):
+        request_version = version.parse_version_string('9.9')
+        self.assertFalse(request_version.matches((75, 1), (10, 0)))
+
+    def test_matches_no_args_bad_version(self):
+        request_version = version.parse_version_string('9.9')
+        self.assertFalse(request_version.matches())
+
+    def test_matches_no_args_good_version(self):
+        request_version = version.parse_version_string('0.9')
+        self.assertTrue(request_version.matches())
+
+    def test_matches_max_arg(self):
+        request_version = version.parse_version_string('0.9')
+        self.assertTrue(request_version.matches(max_version=(0, 9)))
+
+    def test_matches_min_arg(self):
+        request_version = version.parse_version_string('0.9')
+        self.assertTrue(request_version.matches(min_version=(0, 9)))
+
+    def test_matches_min_arg_bad_version(self):
+        request_version = version.parse_version_string('0.8')
+        self.assertFalse(request_version.matches(min_version=(0, 9)))
+
 
 class TestHeaderExtraction(MockVersionedTest):
 


### PR DESCRIPTION
This makes it easier to do conditionals of the current version
against arbitrary windows of version by setting min_version and
max_version args. The tests show some useful examples.

This should allow sufficent expressiveness to conditionally branch
on version where we like.