### PR TITLE
Implement an error handler

### DIFF
--- a/enamel/main.py
+++ b/enamel/main.py
@@ -14,6 +14,7 @@
 import sys
 
 import flask
+import httpexceptor
 from keystonemiddleware import auth_token
 from oslo_config import cfg
 from oslo_log import log as logging
@@ -27,6 +28,7 @@ LOG = logging.getLogger(__name__)
 
 def create_app(conf):
     app = flask.Flask(__name__)
+    _load_error_handlers(app)
     _load_request_handlers(app)
     _load_routes(app)
     # Here we work around keystone middleware's desire to be brought
@@ -64,6 +66,11 @@ def main(args=sys.argv[1:]):
                   'port': conf.api.bind_port}
 
     app.run(**app_kwargs)
+
+
+def _load_error_handlers(app):
+    app.error_handler_spec[None][None] = [(httpexceptor.HTTPException,
+                                           handlers.handle_error)]
 
 
 def _load_routes(app):

--- a/enamel/tests/functional/gabbi/gabbits/versions.yaml
+++ b/enamel/tests/functional/gabbi/gabbits/versions.yaml
@@ -34,7 +34,6 @@ tests:
         openstack-enamel-api-version: '1.0'
 
     - name: invalid version number
-      xfail: 406 handling does not exist yet
       GET: /
       request_headers:
         content-type: application/json
@@ -42,10 +41,13 @@ tests:
       response_headers:
         vary: /OpenStack-enamel-API-Version/
         openstack-enamel-api-version: '0.1'
+        content-type: application/json
       status: 406
+      response_json_paths:
+          $.errors[0].status: 406
+          $.errors[0].title: Not Acceptable
 
     - name: invalid version string
-      xfail: 406 handling does not exist yet
       GET: /
       request_headers:
         content-type: application/json
@@ -53,4 +55,9 @@ tests:
       response_headers:
         vary: /OpenStack-enamel-API-Version/
         openstack-enamel-api-version: '0.1'
+        content-type: application/json
       status: 406
+      response_json_paths:
+          $.errors[0].status: 406
+          $.errors[0].title: Not Acceptable
+          $.errors[0].detail: "406 Not Acceptable: unable to use provided version: invalid version string: cow"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Flask
 alembic
+httpexceptor>=1.4.0
 keystonemiddleware>=4.3.0
 oslo.config
 oslo.db


### PR DESCRIPTION
This makes it possible to raise HTTP&lt;some status&gt; anywhere in the
code and for it to be properly handled by the Flask app. The
response status will be set and the body will take on the form of an
OpenStack errors object.

This implementation uses my own httpexceptor module. We don't have
to use it by find it simple to use and it is fairly reasonable with
regard to headers it will mess with depending on the exception. For
example for most exception the argument passed is just a message
that goes in the error, whereas for 302 it is expected to be a full
URL for redirection. We can change to something else easily enough.

Version handling now properly raises the expected 406 when given a
bad microversion.