### PR TITLE
Add request-id handling

### DIFF
--- a/enamel/main.py
+++ b/enamel/main.py
@@ -71,6 +71,9 @@ def main(args=sys.argv[1:]):
 def _load_error_handlers(app):
     app.error_handler_spec[None][None] = [(httpexceptor.HTTPException,
                                            handlers.handle_error)]
+    # NOTE(cdent): A special handler is required for Flask's own 404,
+    # it is likely one will be needed for at least 405 too.
+    app.error_handler_spec[None][404] = handlers.handle_404
 
 
 def _load_routes(app):
@@ -88,5 +91,11 @@ def _load_request_handlers(app):
     # We assume here that we are the first thing to mess with
     # before_request_funcs and after_request_funcs. This is true if
     # the before_request and after_request decorators are not used.
-    app.before_request_funcs[None] = [handlers.set_version]
-    app.after_request_funcs[None] = [handlers.send_version]
+    app.before_request_funcs[None] = [
+        handlers.set_request_id,  # keep this first
+        handlers.set_version
+    ]
+    app.after_request_funcs[None] = [
+        handlers.send_version,
+        handlers.send_request_id
+    ]

--- a/enamel/tests/functional/gabbi/gabbits/requestid.yaml
+++ b/enamel/tests/functional/gabbi/gabbits/requestid.yaml
@@ -1,0 +1,19 @@
+# Make sure we get a request id
+
+fixtures:
+- ConfigFixture
+
+tests:
+
+- name: request id present
+  GET: /
+  response_headers:
+      openstack-request-id: /[a-f0-9-]{36}/
+
+- name: error gets a request id
+  GET: /no/you/never/gonna/get/it/not/this/time
+  status: 404
+  response_headers:
+      openstack-request-id: /[a-f0-9-]{36}/
+  response_strings:
+      - '"request_id": "'


### PR DESCRIPTION
This adds a simple uuid4 to every response and makes that uuid
available throughout the request, for logging and related purposes.

During testing it became clear that the error handling would not
work for 404s that Flask itself was raising so those are repackaged
to get them into the error handling flow.