### PR TITLE
Switch to using modern microversion headers

### DIFF
--- a/enamel/api/handlers.py
+++ b/enamel/api/handlers.py
@@ -90,7 +90,7 @@ def send_version(response):
             response.headers['vary'] = '%s, %s' % (vary, header)
         else:
             response.headers['vary'] = header
-        response.headers[header] = value
+        response.headers[header] = '%s %s' % (version.SERVICE_TYPE, value)
     return response
 
 

--- a/enamel/api/version.py
+++ b/enamel/api/version.py
@@ -95,28 +95,21 @@ def extract_version(headers):
     """
     version_string = min_version_string()
 
-    import sys
     # If there are multiple matching headers we want the one at the
     # bottom.
-    sys.stderr.write('headers %s\n' % headers)
     version_header = headers.get(Version.HEADER.lower())
     if version_header:
-        sys.stderr.write('version_header %s\n' % version_header)
         version_header_values = reversed(headers.get(
             Version.HEADER.lower(), '').split(','))
 
         for value in version_header_values:
-            sys.stderr.write('value %s\n' % value)
             try:
                 service_type, version = value.lstrip().split(None, 1)
-                sys.stderr.write('stv %s: %s\n' % (service_type, version))
             except ValueError:
-                sys.stderr.write('value error!\n')
                 # The header was unsplittable.
                 continue
             if service_type.lower() == SERVICE_TYPE:
                 version_string = version
-                sys.stderr.write('version_string %s\n' % version_string)
                 break
 
     request_version = parse_version_string(version_string)

--- a/enamel/tests/functional/gabbi/gabbits/versions.yaml
+++ b/enamel/tests/functional/gabbi/gabbits/versions.yaml
@@ -12,35 +12,44 @@ tests:
       request_headers:
         content-type: application/json
       response_headers:
-        vary: /OpenStack-enamel-API-Version/
-        openstack-enamel-api-version: '0.1'
+        vary: /OpenStack-API-Version/
+        openstack-api-version: enamel 0.1
+
+    - name: latest version untyped is min
+      GET: /
+      request_headers:
+        content-type: application/json
+        openstack-api-version: latest
+      response_headers:
+        vary: /OpenStack-API-Version/
+        openstack-api-version: enamel 0.1
 
     - name: latest version
       GET: /
       request_headers:
         content-type: application/json
-        openstack-enamel-api-version: latest
+        openstack-api-version: enamel latest
       response_headers:
-        vary: /OpenStack-enamel-API-Version/
-        openstack-enamel-api-version: '1.0'
+        vary: /OpenStack-API-Version/
+        openstack-api-version: enamel 1.0
 
     - name: specific version
       GET: /
       request_headers:
         content-type: application/json
-        openstack-enamel-api-version: '1.0'
+        openstack-api-version: enamel 1.0
       response_headers:
-        vary: /OpenStack-enamel-API-Version/
-        openstack-enamel-api-version: '1.0'
+        vary: /OpenStack-API-Version/
+        openstack-api-version: enamel 1.0
 
     - name: invalid version number
       GET: /
       request_headers:
         content-type: application/json
-        openstack-enamel-api-version: '0.5'
+        openstack-api-version: enamel 0.5
       response_headers:
-        vary: /OpenStack-enamel-API-Version/
-        openstack-enamel-api-version: '0.1'
+        vary: /OpenStack-API-Version/
+        openstack-api-version: enamel 0.1
         content-type: application/json
       status: 406
       response_json_paths:
@@ -51,13 +60,31 @@ tests:
       GET: /
       request_headers:
         content-type: application/json
-        openstack-enamel-api-version: cow
+        openstack-api-version: enamel cow
       response_headers:
-        vary: /OpenStack-enamel-API-Version/
-        openstack-enamel-api-version: '0.1'
+        vary: /OpenStack-API-Version/
+        openstack-api-version: enamel 0.1
         content-type: application/json
       status: 406
       response_json_paths:
           $.errors[0].status: 406
           $.errors[0].title: Not Acceptable
           $.errors[0].detail: "406 Not Acceptable: unable to use provided version: invalid version string: cow"
+
+    - name: multiple version string one good
+      GET: /
+      request_headers:
+        content-type: application/json
+        openstack-api-version: enamel 0.9,compute 2.11
+      response_headers:
+        vary: /OpenStack-API-Version/
+        openstack-api-version: enamel 0.9
+
+    - name: multiple version string none good
+      GET: /
+      request_headers:
+        content-type: application/json
+        openstack-api-version: identity 0.9,compute 2.11
+      response_headers:
+        vary: /OpenStack-API-Version/
+        openstack-api-version: enamel 0.1

--- a/enamel/tests/integration/gabbi/gabbits/integration.yaml
+++ b/enamel/tests/integration/gabbi/gabbits/integration.yaml
@@ -7,7 +7,7 @@
 defaults:
     request_headers:
         x-auth-token: $ENVIRON['AUTH_TOKEN']
-        openstack-enamel-api-version: latest
+        openstack-api-version: enamel latest
 
 tests:
 

--- a/enamel/tests/unit/api/test_version.py
+++ b/enamel/tests/unit/api/test_version.py
@@ -83,11 +83,11 @@ class TestVersion(MockVersionedTest):
         self.assertGreater(huge_version, min_version)
 
     def test_header_is_good(self):
-        self.assertEqual('OpenStack-enamel-API-Version',
+        self.assertEqual('OpenStack-API-Version',
                          version.Version.HEADER)
 
         request_version = version.parse_version_string('latest')
-        self.assertEqual('OpenStack-enamel-API-Version',
+        self.assertEqual('OpenStack-API-Version',
                          request_version.HEADER)
 
     def test_matches_does_match(self):
@@ -127,15 +127,15 @@ class TestVersion(MockVersionedTest):
 class TestHeaderExtraction(MockVersionedTest):
 
     def test_correct_headers(self):
-        headers = {'openstack-enamel-api-version':
-                   '0.9'}
+        headers = {'openstack-api-version':
+                   'enamel 0.9'}
         request_version = version.extract_version(headers)
         self.assertEqual(version.parse_version_string('0.9'),
                          request_version)
 
     def test_valid_number_but_not_listed_version(self):
-        headers = {'openstack-enamel-api-version':
-                   '0.8'}
+        headers = {'openstack-api-version':
+                   'enamel 0.8'}
         self.assertRaises(ValueError, version.extract_version, headers)
 
     def test_missing_header(self):
@@ -144,39 +144,51 @@ class TestHeaderExtraction(MockVersionedTest):
         self.assertEqual(request_version.min_version, request_version)
 
     def test_latest_header(self):
-        headers = {'openstack-enamel-api-version':
-                   'latest'}
+        headers = {'openstack-api-version':
+                   'enamel latest'}
         request_version = version.extract_version(headers)
         self.assertEqual(request_version.max_version, request_version)
 
     def test_huge_header(self):
-        headers = {'openstack-enamel-api-version':
-                   '9999.9999'}
+        headers = {'openstack-api-version':
+                   'enamel 9999.9999'}
         self.assertRaises(ValueError, version.extract_version, headers)
 
-    def test_weird_header(self):
-        headers = {'openstack-enamel-api-version':
-                   '1.0 bottles of sangria'}
+    def test_weird_but_typed_header(self):
+        headers = {'openstack-api-version':
+                   'enamel 1.0 bottles of sangria'}
         self.assertRaises(ValueError, version.extract_version, headers)
+
+    def test_weird_untyped_header(self):
+        headers = {'openstack-api-version':
+                   '1.0 bottles of sangria'}
+        request_version = version.extract_version(headers)
+        self.assertEqual(request_version.min_version, request_version)
 
     def test_whitespacey_header(self):
-        headers = {'openstack-enamel-api-version':
-                   '  1.0         '}
+        headers = {'openstack-api-version':
+                   '   enamel  1.0         '}
         request_version = version.extract_version(headers)
         self.assertEqual(version.Version(1, 0), request_version)
 
     def test_weird_whitespacey_header(self):
-        headers = {'openstack-enamel-api-version':
-                   '  1  .   0         '}
+        headers = {'openstack-api-version':
+                   'enamel   1  .   0         '}
         request_version = version.extract_version(headers)
         self.assertEqual(version.Version(1, 0), request_version)
 
-    def test_cows_in_header(self):
-        headers = {'openstack-enamel-api-version':
+    def test_cows_in_header_no_service(self):
+        headers = {'openstack-api-version':
                    '  1  .   cow         '}
+        request_version = version.extract_version(headers)
+        self.assertEqual(request_version.min_version, request_version)
+
+    def test_cows_header_good_service(self):
+        headers = {'openstack-api-version':
+                   '  enamel     cow         '}
         self.assertRaises(ValueError, version.extract_version, headers)
 
     def test_negative_header(self):
-        headers = {'openstack-enamel-api-version':
-                   ' -1.9'}
+        headers = {'openstack-api-version':
+                   'enamel -1.9'}
         self.assertRaises(ValueError, version.extract_version, headers)


### PR DESCRIPTION
The proposed new styleeee is "OpenStack-API-Version: <type> <version>"

This change implements that and updates the tests accordingly.

The proposal has not yet been approved but has support from the cores
of the API-wg and Nova and Ironic are okay with it as is. Manila
is okay as long as there is some grandfathering.