### PR TITLE
Add Task oslo.versionedobject

### DIFF
--- a/enamel/main.py
+++ b/enamel/main.py
@@ -20,6 +20,7 @@ from oslo_config import cfg
 from oslo_log import log as logging
 
 from enamel.api import handlers
+from enamel import objects
 from enamel import opts
 
 
@@ -59,6 +60,7 @@ def prepare_service(args=None):
 
 
 def main(args=sys.argv[1:]):
+    objects.register_all()
     conf = prepare_service(args)
 
     app = create_app(conf)

--- a/enamel/objects/__init__.py
+++ b/enamel/objects/__init__.py
@@ -1,0 +1,25 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+# NOTE(comstud): You may scratch your head as you see code that imports
+# this module and then accesses attributes for objects such as Instance,
+# etc, yet you do not see these attributes in here. Never fear, there is
+# a little bit of magic. When objects are registered, an attribute is set
+# on this module automatically, pointing to the newest/latest version of
+# the object.
+
+
+def register_all():
+    # NOTE(danms): You must make sure your object gets imported in this
+    # function in order for it to be registered by services that may
+    # need to receive it via RPC.
+    __import__('enamel.objects.task')

--- a/enamel/objects/base.py
+++ b/enamel/objects/base.py
@@ -1,0 +1,32 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from oslo_versionedobjects import base
+from oslo_versionedobjects import fields
+
+
+class EnamelObject(base.VersionedObject):
+    OBJ_PROJECT_NAMESPACE = 'enamel'
+
+
+class EnamelTimestampObject(object):
+    """Mixin class for db backed objects with timestamp fields.
+
+    Sqlalchemy models that inherit from the oslo_db TimestampMixin will include
+    these fields and the corresponding objects will benefit from this mixin.
+    """
+    fields = {
+        'created_at': fields.DateTimeField(nullable=True),
+        'updated_at': fields.DateTimeField(nullable=True),
+             }

--- a/enamel/objects/task.py
+++ b/enamel/objects/task.py
@@ -1,0 +1,71 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from oslo_versionedobjects import base as ovo_base
+from oslo_versionedobjects import fields
+
+from enamel.db import models as db_models
+from enamel.db import utils as db_utils
+from enamel.objects import base
+
+
+@ovo_base.VersionedObjectRegistry.register
+class Task(base.EnamelTimestampObject, base.EnamelObject):
+    # Version 1.0: Initial version
+    VERSION = '1.0'
+
+    fields = {
+        'id': fields.IntegerField(read_only=True),
+        'uuid': fields.UUIDField(),
+        'action': fields.StringField(),
+        'state': fields.StringField(),
+        'request_id': fields.StringField(),
+        'user_id': fields.StringField(),
+        'project_id': fields.StringField(),
+        'params': fields.StringField(),
+        'ended_at': fields.DateTimeField(nullable=True),
+    }
+
+    @staticmethod
+    def _from_db_object(task, db_task):
+        for key in task.fields:
+            setattr(task, key, db_task[key])
+            task.obj_reset_changes()
+        return task
+
+    # TODO(alaski): Pass context through from middleware so oslo.db
+    # EngineFacade work can be used.
+    @staticmethod
+    def _get_by_uuid_from_db(uuid):
+        session = db_utils.get_session()
+        db_task = session.query(db_models.Task).filter_by(uuid=uuid).first()
+
+        # TODO(alaski): raise exception if db_task not found
+        return db_task
+
+    @classmethod
+    def get_by_uuid(cls, uuid):
+        db_task = cls._get_by_uuid_from_db(uuid)
+        return cls._from_db_object(cls(), db_task)
+
+    @staticmethod
+    def _create_in_db(updates):
+        session = db_utils.get_session()
+        db_task = db_models.Task()
+        db_task.update(updates)
+        db_task.save(session)
+        return db_task
+
+    def create(self):
+        db_task = self._create_in_db(self.obj_get_changes())
+        self._from_db_object(self, db_task)

--- a/enamel/tests/fixtures.py
+++ b/enamel/tests/fixtures.py
@@ -1,0 +1,54 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Without this 'import fixtures' actually imports enamel.tests.fixtures
+from __future__ import absolute_import
+
+import fixtures
+
+from enamel.db import sync as db_sync
+from enamel.db import utils as db_utils
+
+DB_SCHEMA = ''
+
+
+class Database(fixtures.Fixture):
+    def __init__(self):
+        super(Database, self).__init__()
+        self.get_engine = db_utils.get_engine
+
+    def setUp(self):
+        super(Database, self).setUp()
+        self.reset()
+        self.addCleanup(self.cleanup)
+
+    def _cache_schema(self):
+        global DB_SCHEMA
+        if not DB_SCHEMA:
+            engine = self.get_engine()
+            conn = engine.connect()
+            alemb_conf = db_sync.get_alembic_config()
+            db_sync.do_alembic_command(alemb_conf, 'upgrade', revision='head')
+            DB_SCHEMA = "".join(line for line in conn.connection.iterdump())
+
+    def cleanup(self):
+        engine = self.get_engine()
+        engine.dispose()
+
+    def reset(self):
+        self._cache_schema()
+        engine = self.get_engine()
+        engine.dispose()
+        conn = engine.connect()
+        conn.connection.executescript(DB_SCHEMA)

--- a/enamel/tests/functional/db/test_task.py
+++ b/enamel/tests/functional/db/test_task.py
@@ -1,0 +1,46 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from oslo_utils import uuidutils
+
+from enamel.objects import task
+from enamel.tests import fixtures
+from enamel.tests.unit import base as test_base
+
+
+class TaskTestCase(test_base.DBTestCase):
+    def setUp(self):
+        super(TaskTestCase, self).setUp()
+        self.useFixture(fixtures.Database())
+        self._task_obj = task.Task()
+
+    _sample_task = {
+            'uuid': uuidutils.generate_uuid(),
+            'action': 'boot_server',
+            'state': 'in-progress',
+            'request_id': 'req-foo',
+            'user_id': 'foo',
+            'project_id': 'bar',
+            'params': '',
+    }
+
+    def _create_task(self):
+        args = self._sample_task.copy()
+        return self._task_obj._create_in_db(args)
+
+    def test_get_by_uuid(self):
+        task = self._create_task()
+        db_task = self._task_obj._get_by_uuid_from_db(task['uuid'])
+        for field in self._task_obj.fields.keys():
+            self.assertEqual(task[field], db_task[field])

--- a/enamel/tests/unit/base.py
+++ b/enamel/tests/unit/base.py
@@ -13,6 +13,18 @@
 
 import testtools
 
+from oslo_config import cfg
+from oslo_db import options as db_options
+
+from enamel.db import utils as db_utils
+
 
 class TestCase(testtools.TestCase):
     pass
+
+
+class DBTestCase(testtools.TestCase):
+    conf = cfg.ConfigOpts()
+    db_options.set_defaults(conf, connection='sqlite://')
+    conf(args=[], project='enamel')
+    db_utils.init(conf)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ oslo.config
 oslo.db
 oslo.log
 oslo.utils
+oslo.versionedobjects
 python-cinderclient
 python-glanceclient
 python-novaclient


### PR DESCRIPTION
In order to interact with the database it was decided that we would use
oslo.versionedobjects with embedded query methods. This adds the basic
framework for adding objects to enamel, adds the first object, and adds
a test class and fixture for easy testing of the database interactions.