### PR TITLE
Add an accept decorator

### DIFF
--- a/enamel/api/decorators.py
+++ b/enamel/api/decorators.py
@@ -1,0 +1,39 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+
+import flask
+import httpexceptor
+
+
+ACCEPTABLE_TYPES = ['application/json', 'application/vnd.enamel+json']
+
+
+def accept(types=ACCEPTABLE_TYPES):
+    """Decorate a route to only accept given types.
+
+    Note that this makes no account for quality statements within accept
+    headers. In the current environment this is satisfactory as we are
+    not providing different serializations of resources.
+    """
+    def decorator(f):
+        @functools.wraps(f)
+        def decorated_function(*args, **kwargs):
+            acceptable = flask.request.accept_mimetypes.values()
+            if not set.intersection(set(acceptable), set(types)):
+                raise httpexceptor.HTTP406('Need %s' % types)
+            else:
+                return f(*args, **kwargs)
+        return decorated_function
+    return decorator

--- a/enamel/api/errors.py
+++ b/enamel/api/errors.py
@@ -1,0 +1,47 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import flask
+import httpexceptor
+
+
+def handle_error(error):
+    """Trap an HTTPException and package it for display"""
+    # This current implementation is based on the httpexceptor model
+    # which provides a very simple way to raise an HTTP<some status>
+    # anywhere. This takes that exception, extracts meaning from it
+    # and puts it in the format of an OpenStack errors object.
+
+    status_code, title = error.status.split(' ', 1)
+    # httpexcepter body() is a one item list of bytestring
+    body_detail = error.body()[0].decode('utf-8')
+
+    response = flask.jsonify({'errors': [{
+        'status': int(status_code),
+        'request_id': flask.g.request_id,
+        'title': title,
+        'detail': body_detail,
+    }]})
+
+    response.status = error.status
+    for header, value in error.headers():
+        if header.lower() == 'content-type':
+            continue
+        response.headers[header] = value
+    return response
+
+
+def handle_404(error):
+    """Transform a Flask 404 into our error handling flow."""
+    return handle_error(httpexceptor.HTTP404(error.description))

--- a/enamel/api/handlers.py
+++ b/enamel/api/handlers.py
@@ -16,7 +16,7 @@ import re
 
 import flask
 
-from enamel.api.decorators import accept
+from enamel.api import decorators
 
 
 def create_link_object(urls):
@@ -37,7 +37,7 @@ def generate_resource_data(resources):
     return data
 
 
-@accept()
+@decorators.accept()
 def home():
     pat = re.compile("^\/[^\/]*?$")
 

--- a/enamel/api/request_funcs.py
+++ b/enamel/api/request_funcs.py
@@ -1,0 +1,57 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import flask
+import httpexceptor
+from oslo_utils import uuidutils
+
+from enamel.api import version
+
+
+REQUEST_ID_HEADER = 'Openstack-Request-ID'
+
+
+def set_request_id():
+    """A before_request function to set required-id."""
+    flask.g.request_id = uuidutils.generate_uuid()
+
+
+def send_request_id(response):
+    """An after_request_function to send request-id header."""
+    response.headers[REQUEST_ID_HEADER] = flask.g.request_id
+    return response
+
+
+def set_version():
+    """A before_request function to set microversion."""
+    try:
+        flask.g.request_version = version.extract_version(
+            flask.request.headers)
+    except ValueError as exc:
+        flask.g.request_version = version.parse_version_string(
+            version.min_version_string())
+        raise httpexceptor.HTTP406('unable to use provided version: %s' % exc)
+
+
+def send_version(response):
+    """An after_request function to send microversion headers."""
+    vary = response.headers.get('vary')
+    header = version.Version.HEADER
+    value = flask.g.get('request_version')
+    if value:
+        if vary:
+            response.headers['vary'] = '%s, %s' % (vary, header)
+        else:
+            response.headers['vary'] = header
+        response.headers[header] = '%s %s' % (version.SERVICE_TYPE, value)
+    return response

--- a/enamel/cmd/api.py
+++ b/enamel/cmd/api.py
@@ -20,7 +20,9 @@ from keystonemiddleware import auth_token
 from oslo_config import cfg
 from oslo_log import log as logging
 
+from enamel.api import errors
 from enamel.api import handlers
+from enamel.api import request_funcs
 from enamel import objects
 from enamel import opts
 
@@ -73,10 +75,10 @@ def main(args=sys.argv[1:]):
 
 def _load_error_handlers(app):
     app.error_handler_spec[None][None] = [(httpexceptor.HTTPException,
-                                           handlers.handle_error)]
+                                           errors.handle_error)]
     # NOTE(cdent): A special handler is required for Flask's own 404,
     # it is likely one will be needed for at least 405 too.
-    app.error_handler_spec[None][404] = handlers.handle_404
+    app.error_handler_spec[None][404] = errors.handle_404
 
 
 def _load_routes(app):
@@ -95,12 +97,12 @@ def _load_request_handlers(app):
     # before_request_funcs and after_request_funcs. This is true if
     # the before_request and after_request decorators are not used.
     app.before_request_funcs[None] = [
-        handlers.set_request_id,  # keep this first
-        handlers.set_version
+        request_funcs.set_request_id,  # keep this first
+        request_funcs.set_version
     ]
     app.after_request_funcs[None] = [
-        handlers.send_version,
-        handlers.send_request_id
+        request_funcs.send_version,
+        request_funcs.send_request_id
     ]
 
 

--- a/enamel/tests/functional/gabbi/gabbits/accept.yaml
+++ b/enamel/tests/functional/gabbi/gabbits/accept.yaml
@@ -1,0 +1,26 @@
+# test accept header handling
+
+fixtures:
+- ConfigFixture
+
+tests:
+
+- name: good accept
+  GET: /
+  request_headers:
+      accept: application/json
+  status: 200
+
+- name: other good accept
+  GET: /
+  request_headers:
+      accept: application/vnd.enamel+json
+  status: 200
+
+- name: bad accept
+  GET: /
+  request_headers:
+      accept: application/xml
+  status: 406
+  response_json_paths:
+      $.errors[0].status: 406

--- a/enamel/tests/functional/gabbi/gabbits/requestid.yaml
+++ b/enamel/tests/functional/gabbi/gabbits/requestid.yaml
@@ -7,6 +7,8 @@ tests:
 
 - name: request id present
   GET: /
+  request_headers:
+      accept: application/json
   response_headers:
       openstack-request-id: /[a-f0-9-]{36}/
 

--- a/enamel/tests/functional/gabbi/gabbits/versions.yaml
+++ b/enamel/tests/functional/gabbi/gabbits/versions.yaml
@@ -10,7 +10,7 @@ tests:
       desc: no header sent
       GET: /
       request_headers:
-        content-type: application/json
+        accept: application/json
       response_headers:
         vary: /OpenStack-API-Version/
         openstack-api-version: enamel 0.1
@@ -18,7 +18,7 @@ tests:
     - name: latest version untyped is min
       GET: /
       request_headers:
-        content-type: application/json
+        accept: application/json
         openstack-api-version: latest
       response_headers:
         vary: /OpenStack-API-Version/
@@ -27,7 +27,7 @@ tests:
     - name: latest version
       GET: /
       request_headers:
-        content-type: application/json
+        accept: application/json
         openstack-api-version: enamel latest
       response_headers:
         vary: /OpenStack-API-Version/
@@ -36,7 +36,7 @@ tests:
     - name: specific version
       GET: /
       request_headers:
-        content-type: application/json
+        accept: application/json
         openstack-api-version: enamel 1.0
       response_headers:
         vary: /OpenStack-API-Version/
@@ -45,7 +45,7 @@ tests:
     - name: invalid version number
       GET: /
       request_headers:
-        content-type: application/json
+        accept: application/json
         openstack-api-version: enamel 0.5
       response_headers:
         vary: /OpenStack-API-Version/
@@ -59,7 +59,7 @@ tests:
     - name: invalid version string
       GET: /
       request_headers:
-        content-type: application/json
+        accept: application/json
         openstack-api-version: enamel cow
       response_headers:
         vary: /OpenStack-API-Version/
@@ -74,7 +74,7 @@ tests:
     - name: multiple version string one good
       GET: /
       request_headers:
-        content-type: application/json
+        accept: application/json
         openstack-api-version: enamel 0.9,compute 2.11
       response_headers:
         vary: /OpenStack-API-Version/
@@ -83,7 +83,7 @@ tests:
     - name: multiple version string none good
       GET: /
       request_headers:
-        content-type: application/json
+        accept: application/json
         openstack-api-version: identity 0.9,compute 2.11
       response_headers:
         vary: /OpenStack-API-Version/


### PR DESCRIPTION
For route handlers that respond to the GET method, add an optional
accept decorator which raises a 406 response code if the accept
header in the request does not match with the media types provided
to the decorator. ACCEPTABLE_TYPES contains defaults.

This gets the basics in place but leaves room for later improvement
in how the body of the 406 response is formed. It could be more useful
if we desire.

In order to make this change in a tidy way that did not drive the
author crazy not route-handling methods have been moved out of
handler.py into decorators.py, errors.py and request_funcs.py depending
on what kind of function those methods provided.

Various gabbits have been updated to reflect the required accept header
and also correct the fact that I dumbly used content-type where I meant
accept.