### PR TITLE
Add TaskItem object

### DIFF
--- a/enamel/objects/__init__.py
+++ b/enamel/objects/__init__.py
@@ -23,3 +23,4 @@ def register_all():
     # function in order for it to be registered by services that may
     # need to receive it via RPC.
     __import__('enamel.objects.task')
+    __import__('enamel.objects.task_item')

--- a/enamel/objects/task_item.py
+++ b/enamel/objects/task_item.py
@@ -1,0 +1,69 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from oslo_versionedobjects import base as ovo_base
+from oslo_versionedobjects import fields
+
+from enamel.db import models as db_models
+from enamel.db import utils as db_utils
+from enamel.objects import base
+
+
+@ovo_base.VersionedObjectRegistry.register
+class TaskItem(base.EnamelTimestampObject, base.EnamelObject):
+    # Version 1.0: Initial version
+    VERSION = '1.0'
+
+    fields = {
+        'id': fields.IntegerField(read_only=True),
+        'uuid': fields.UUIDField(),
+        'action': fields.StringField(),
+        'state': fields.StringField(),
+        'task_id': fields.IntegerField(),
+        'ended_at': fields.DateTimeField(nullable=True),
+    }
+
+    @staticmethod
+    def _from_db_object(task_item, db_task_item):
+        for key in task_item.fields:
+            setattr(task_item, key, db_task_item[key])
+            task_item.obj_reset_changes()
+        return task_item
+
+    # TODO(alaski): Pass context through from middleware so oslo.db
+    # EngineFacade work can be used.
+    @staticmethod
+    def _get_by_uuid_from_db(uuid):
+        session = db_utils.get_session()
+        db_task_item = session.query(db_models.TaskItem).filter_by(
+                                                            uuid=uuid).first()
+
+        # TODO(alaski): raise exception if db_task_item not found
+        return db_task_item
+
+    @classmethod
+    def get_by_uuid(cls, uuid):
+        db_task_item = cls._get_by_uuid_from_db(uuid)
+        return cls._from_db_object(cls(), db_task_item)
+
+    @staticmethod
+    def _create_in_db(updates):
+        session = db_utils.get_session()
+        db_task_item = db_models.TaskItem()
+        db_task_item.update(updates)
+        db_task_item.save(session)
+        return db_task_item
+
+    def create(self):
+        db_task_item = self._create_in_db(self.obj_get_changes())
+        self._from_db_object(self, db_task_item)

--- a/enamel/tests/functional/db/test_task_item.py
+++ b/enamel/tests/functional/db/test_task_item.py
@@ -1,0 +1,58 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from oslo_utils import uuidutils
+
+from enamel.objects import task
+from enamel.objects import task_item
+from enamel.tests import fixtures
+from enamel.tests.unit import base as test_base
+
+
+class TaskItemTestCase(test_base.DBTestCase):
+    def setUp(self):
+        super(TaskItemTestCase, self).setUp()
+        self.useFixture(fixtures.Database())
+
+    _sample_task = {
+            'uuid': uuidutils.generate_uuid(),
+            'action': 'boot_server',
+            'state': 'in-progress',
+            'request_id': 'req-foo',
+            'user_id': 'foo',
+            'project_id': 'bar',
+            'params': '',
+    }
+
+    _sample_task_item = {
+            'uuid': uuidutils.generate_uuid(),
+            'action': 'create_volume',
+            'state': 'in-progress',
+            'task_id': None,
+    }
+
+    def _create_task_item(self):
+        task_args = self._sample_task.copy()
+        tsk = task.Task._create_in_db(task_args)
+        task_item_args = self._sample_task_item.copy()
+        task_item_args['task_id'] = tsk.id
+        tsk_item = task_item.TaskItem._create_in_db(task_item_args)
+        return tsk_item
+
+    def test_get_by_uuid(self):
+        tsk_item = self._create_task_item()
+        db_task_item = task_item.TaskItem._get_by_uuid_from_db(
+                tsk_item['uuid'])
+        for field in task_item.TaskItem.fields.keys():
+            self.assertEqual(tsk_item[field], db_task_item[field])


### PR DESCRIPTION
This adds a TaskItem object to be used for interacting with the
task_items database table. It will eventually be useful for passing over
RPC as well if necessary.